### PR TITLE
Specify repo that will host test run results

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled.yaml
@@ -372,6 +372,8 @@ jobs:
       # This would be `skipped` if `setup` is skipped.
       setup_status: ${{ needs.setup.result }}
       slack_report_channel: ${{ inputs.slack_report_channel }}
+      report_repo_id: "optimum-amd/transformers_daily_ci"
+      upload_report_summary: true
       # This would be an empty string if `setup` is skipped.
       folder_slices: ${{ needs.setup.outputs.folder_slices }}
       quantization_matrix: ${{ needs.setup.outputs.quantization_matrix }}

--- a/.github/workflows/transformers_amd_ci_scheduled.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled.yaml
@@ -373,7 +373,6 @@ jobs:
       setup_status: ${{ needs.setup.result }}
       slack_report_channel: ${{ inputs.slack_report_channel }}
       report_repo_id: "optimum-amd/transformers_daily_ci"
-      upload_report_summary: true
       # This would be an empty string if `setup` is skipped.
       folder_slices: ${{ needs.setup.outputs.folder_slices }}
       quantization_matrix: ${{ needs.setup.outputs.quantization_matrix }}


### PR DESCRIPTION
This uses the two new flags in the transformers `slack-report` job where you can specify the repo that will contain test results as well as a flag for if you want to upload the summary of the test run (same as slack message).

I will merge this and https://github.com/huggingface/transformers/pull/35058 when everything is ready.