### PR TITLE
Run model tests in parallel

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled.yaml
@@ -140,7 +140,6 @@ jobs:
     name: Single GPU tests
     needs: setup
     strategy:
-      max-parallel: 1 # For now, not to parallelize. Can change later if it works well.
       fail-fast: false
       matrix:
         machine_type: [single-gpu, multi-gpu]


### PR DESCRIPTION
This should significantly reduce the total time of the CI, and I don't think there are any negative effects given that the tests are running in gpu isolation.