### PR TITLE
Remove `amd-smi list` calls

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled.yaml
@@ -66,9 +66,6 @@ jobs:
       image: huggingface/transformers-pytorch-amd-gpu
       options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
-      - name: AMD-SMI
-        run: amd-smi list
-
       - name: ROCM-INFO
         run: rocminfo | grep "Agent" -A 14
 
@@ -119,9 +116,6 @@ jobs:
         run: |
           echo "folder_slices=$(python3 ../utils/split_model_tests.py --num_splits ${{ env.NUM_SLICES }})" >> $GITHUB_OUTPUT
           echo "slice_ids=$(python3 -c 'd = list(range(${{ env.NUM_SLICES }})); print(d)')" >> $GITHUB_OUTPUT
-
-      - name: AMD-SMI
-        run: amd-smi list
 
       - name: ROCM-INFO
         run: rocminfo | grep "Agent" -A 14
@@ -179,9 +173,6 @@ jobs:
       - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
-
-      - name: AMD-SMI
-        run: amd-smi list
 
       - name: ROCM-INFO
         run: rocminfo | grep "Agent" -A 14
@@ -241,9 +232,6 @@ jobs:
       - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
-
-      - name: AMD-SMI
-        run: amd-smi list
 
       - name: ROCM-INFO
         run: rocminfo | grep "Agent" -A 14
@@ -305,9 +293,6 @@ jobs:
       - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
-
-      - name: AMD-SMI
-        run: amd-smi list
 
       - name: ROCM-INFO
         run: rocminfo | grep "Agent" -A 14

--- a/.github/workflows/transformers_amd_model_jobs.yaml
+++ b/.github/workflows/transformers_amd_model_jobs.yaml
@@ -90,9 +90,6 @@ jobs:
         run: |
           python3 -m pip install --no-cache-dir git+https://github.com/huggingface/accelerate@main#egg=accelerate
 
-      - name: AMD-SMI
-        run: amd-smi list
-
       - name: ROCM-INFO
         run: |
           rocminfo  | grep "Agent" -A 14


### PR DESCRIPTION
Remove `amd-smi list` calls because it sporadically segfaults in the CI (and only in CI - very hard to reproduce)