### PR TITLE
Fix the runner scale set name in model jobs workflow

### DIFF
--- a/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         folders: ${{ fromJson(inputs.folder_slices)[inputs.slice_id] }}
-    runs-on: ${{ inputs.runner_scale_set }}_${{ inputs.machine_type }}
+    runs-on: ${{ inputs.runner_scale_set }}-${{ inputs.machine_type }}
     container:
       image: ${{ inputs.docker }}
       options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/


### PR DESCRIPTION
As part of setting up the mi300 runner scale set workflow, the runner name was incorrectly set in the workflow. 

Requested labels: amd-mi300-ci_1gpu
Actual label: amd-mi300-ci-1gpu