### PR TITLE
Use an env file to pass in GPU isolation env variables to docker

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: huggingface/transformers-pytorch-amd-gpu
-      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: ROCM-INFO
         run: rocminfo | grep "Agent" -A 14
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: huggingface/transformers-pytorch-amd-gpu
-      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     outputs:
       folder_slices: ${{ steps.set-matrix.outputs.folder_slices }}
       slice_ids: ${{ steps.set-matrix.outputs.slice_ids }}
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: Update clone
         working-directory: /transformers
@@ -182,7 +182,7 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: Update clone
         working-directory: /transformers
@@ -237,7 +237,7 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: Update clone
         working-directory: /transformers

--- a/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ inputs.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --env HIP_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: Echo input and matrix info
         shell: bash


### PR DESCRIPTION
Passing GPU isolation settings to the docker container create command. The environment variables ROCR_VISIBLE_DEVICES and HIP_VISIBLE_DEVICES can't be permanently set on the runner scale set as the runners are ephemeral and also because the variables are created from which gpu device is attached to the runner (/dev/dri/renderD*) **after the runner is created**. 

So either the runner should be patched, with the gpu isolation environment settings, before it is assigned a job, or those settings can be passed to the docker create command in the github job. This PR is using the latter approach.

The runner scale sets **amd-mi300-ci-1gpu** and **amd-mi300-ci-2gpu** are saving the env file in /etc/podinfo/gha-gpu-isolation-settings. 

Test run in personal fork: https://github.com/jitesh-gupta/transformers/actions/runs/15105144833/job/42452469369

References:
https://rocm.docs.amd.com/en/latest/conceptual/gpu-isolation.html
https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html#restricting-gpu-access
https://rocm.blogs.amd.com/software-tools-optimization/compute-memory-modes/README.html

