### PR TITLE
Enable parallel model jobs on default self-hosted amd runners

### DIFF
--- a/.github/workflows/transformers_amd_model_jobs.yaml
+++ b/.github/workflows/transformers_amd_model_jobs.yaml
@@ -37,7 +37,6 @@ jobs:
   run_models_gpu:
     name: " "
     strategy:
-      max-parallel: 1 # For now, not to parallelize. Can change later if it works well.
       fail-fast: false
       matrix:
         folders: ${{ fromJson(inputs.folder_slices)[inputs.slice_id] }}


### PR DESCRIPTION
Identical to the scale set variant