### PR TITLE
[swift-transformers] Update secret token

### DIFF
--- a/.github/workflows/swift_transformers_unit_tests.yml
+++ b/.github/workflows/swift_transformers_unit_tests.yml
@@ -13,5 +13,5 @@ jobs:
     - name: Run tests
       env:
         CI_DISABLE_NETWORK_MONITOR: 1
-        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
       run: swift test --vv --skip-build


### PR DESCRIPTION
I don't know what I'm doing. I thought that `HF_TOKEN` had to be defined in the source repo, but [it's not being forwarded](https://github.com/huggingface/swift-transformers/actions/runs/16679318217/job/47213807857?pr=213) (most possibly for security reasons when people open PRs from forks). I'm here trying to reuse `HF_HUB_READ_TOKEN`, which I saw being used in other workflows. I assume it's defined as a secret of _this_ repo; if so, it should work, since the repos we need to access are all public.

cc @ivarflakstad 🙏 