### PR TITLE
Take env_file as optional input to scale set CI jobs

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
@@ -24,6 +24,9 @@ on:
       report_repo_id:
         required: true
         type: string
+      env_file:
+        required: false
+        type: string
 
 env:
   HF_HOME: /mnt/cache
@@ -44,7 +47,13 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: huggingface/transformers-pytorch-amd-gpu
-      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --shm-size "16gb"
+        --ipc host
+        -v /mnt/cache/.cache/huggingface:/mnt/cache/
+        ${{ inputs.env_file && format('--env-file {0}', inputs.env_file) || '' }}
     steps:
       - name: ROCM-INFO
         run: rocminfo | grep "Agent" -A 14
@@ -64,7 +73,13 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: huggingface/transformers-pytorch-amd-gpu
-      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --shm-size "16gb"
+        --ipc host
+        -v /mnt/cache/.cache/huggingface:/mnt/cache/
+        ${{ inputs.env_file && format('--env-file {0}', inputs.env_file) || '' }}
     outputs:
       folder_slices: ${{ steps.set-matrix.outputs.folder_slices }}
       slice_ids: ${{ steps.set-matrix.outputs.slice_ids }}
@@ -132,7 +147,13 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --shm-size "16gb"
+        --ipc host
+        -v /mnt/cache/.cache/huggingface:/mnt/cache/
+        ${{ inputs.env_file && format('--env-file {0}', inputs.env_file) || '' }}
     steps:
       - name: Update clone
         working-directory: /transformers
@@ -198,7 +219,13 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --shm-size "16gb"
+        --ipc host
+        -v /mnt/cache/.cache/huggingface:/mnt/cache/
+        ${{ inputs.env_file && format('--env-file {0}', inputs.env_file) || '' }}
     steps:
       - name: Update clone
         working-directory: /transformers
@@ -266,7 +293,13 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ matrix.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --shm-size "16gb"
+        --ipc host
+        -v /mnt/cache/.cache/huggingface:/mnt/cache/
+        ${{ inputs.env_file && format('--env-file {0}', inputs.env_file) || '' }}
     steps:
       - name: Update clone
         working-directory: /transformers

--- a/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
@@ -18,6 +18,9 @@ on:
       docker:
         required: true
         type: string
+      env_file:
+        required: false
+        type: string
 
 env:
   HF_HOME: /mnt/cache
@@ -43,7 +46,14 @@ jobs:
     runs-on: ${{ inputs.runner_scale_set }}-${{ inputs.machine_type }}
     container:
       image: ${{ inputs.docker }}
-      options: --device /dev/kfd --device /dev/dri --env-file /etc/podinfo/gha-gpu-isolation-settings --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --shm-size "16gb"
+        --ipc host
+        -v /mnt/cache/.cache/huggingface:/mnt/cache/
+        ${{ inputs.env_file && format('--env-file {0}', inputs.env_file) || '' }}
+
     steps:
       - name: Echo input and matrix info
         shell: bash


### PR DESCRIPTION
Depending on wether we run these jobs in a k8s setting or not the env-file used may or may not be present.
So we simply make it optional and only apply it if needed.

Transformers PR [here](https://github.com/huggingface/transformers/pull/40243)