### PR TITLE
Pass env_file ref into models job

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
@@ -134,6 +134,7 @@ jobs:
       slice_id: ${{ matrix.slice_id }}
       runner_scale_set: ${{ inputs.runner_scale_set }}
       docker: ${{ inputs.docker }}
+      env_file: ${{ inputs.env_file }}
     secrets: inherit
 
   run_pipelines_torch_gpu:


### PR DESCRIPTION
We also need to pass `inputs.env_file` into the models job