### PR TITLE
[swift-transformers] Explicitly declare secret

### DIFF
--- a/.github/workflows/swift_transformers_unit_tests.yml
+++ b/.github/workflows/swift_transformers_unit_tests.yml
@@ -2,6 +2,9 @@ name: Swift Transformers Unit Tests
 
 on:
   workflow_call:
+    secrets:
+      HF_HUB_READ_TOKEN:
+        required: true
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Reference: https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow

- `secrets: inherit` is used [here](https://github.com/huggingface/swift-transformers/blob/ad43b7fce89b03a88bb25fa469bc25e639bab6bc/.github/workflows/unit-tests.yml#L13).
- Workflow runs triggered from PRs opened by contributors don't inherit the secret ([evidence](https://github.com/huggingface/swift-transformers/actions/runs/17577489073/job/49926055649?pr=226#step:4:1132))
- Workflow runs triggered from PRs by org authors do inherit the secret ([evidence](https://github.com/huggingface/swift-transformers/actions/runs/17577428529/job/49925858519#step:4:1102))

I'm not sure if declaring the secret would solve this issue.