### PR TITLE
Remove redundant build step in swift-transformers CI workflow

### DIFF
--- a/.github/workflows/swift_transformers_unit_tests.yml
+++ b/.github/workflows/swift_transformers_unit_tests.yml
@@ -26,11 +26,8 @@ jobs:
         if: ${{ !inputs.pr_number }}
         uses: actions/checkout@v4
 
-      - name: Build
-        run: swift build --vv --build-tests
-
       - name: Run tests
         env:
           CI_DISABLE_NETWORK_MONITOR: 1
           HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
-        run: swift test --vv --skip-build
+        run: swift test --vv


### PR DESCRIPTION
Swift Package Manager can optimize the build graph more effectively when doing everything together. Running `swift build` and then `swift test` in separate steps (even with `--skip-build`) probably adds tens of seconds to CI runtimes.

This PR removes the build step and updates the test step to build and test in one pass.