### PR TITLE
Replace hardcoded docker image value with the input parameter

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: 
       group: ${{ inputs.runner_group }}-${{ matrix.machine_type }}
     container:
-      image: huggingface/transformers-pytorch-amd-gpu
+      image: ${{ inputs.docker }}
       options: >-
         --device /dev/kfd
         --device /dev/dri
@@ -74,7 +74,7 @@ jobs:
     runs-on: 
       group: ${{ inputs.runner_group }}-${{ matrix.machine_type }}
     container:
-      image: huggingface/transformers-pytorch-amd-gpu
+      image: ${{ inputs.docker }}
       options: >-
         --device /dev/kfd
         --device /dev/dri


### PR DESCRIPTION
The `Check Runners` and `Setup` step uses a hardcoded image name rather than the passed in input parameter `docker` from the calling workflow in transformers. 

Although the hardcoded image `huggingface/transformers-pytorch-amd-gpu` is used by 3 out of the 4 jobs in the caller here (https://github.com/huggingface/transformers/blob/307c5238546ba1675daabc46050c63ffde25f8e6/.github/workflows/self-scheduled-amd-mi325-caller.yml), it is still a bug as the `DeepSpeed CI` job uses a different image and the `Check Runner` step for that job uses the hardcoded value mentioned above.

This needs to be fixed first for the next set of changes that we are working on to locally cache the docker image as part of the `Check Runner` step