### PR TITLE
Update `swift test` command to remove `-vv` flags

### DIFF
--- a/.github/workflows/swift_transformers_unit_tests.yml
+++ b/.github/workflows/swift_transformers_unit_tests.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           CI_DISABLE_NETWORK_MONITOR: 1
           HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
-        run: swift test --vv
+        run: swift test


### PR DESCRIPTION
This is causing output from CI runs to be truncated (for example, https://github.com/huggingface/swift-transformers/actions/runs/22179267173/job/64135994157)