### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/optimum_benchmark_instinct_ci.yaml
+++ b/.github/workflows/optimum_benchmark_instinct_ci.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/transformers_amd_ci_push.yaml
+++ b/.github/workflows/transformers_amd_ci_push.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout transformers
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
 
@@ -126,7 +126,7 @@ jobs:
           python3 utils/tests_fetcher.py --diff_with_last_commit | tee test_preparation.txt
 
       - name: Report fetched tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test_fetched
           path: /transformers/test_preparation.txt
@@ -246,7 +246,7 @@ jobs:
 
       - name: "Test suite reports artifacts: ${{ matrix.machine_type }}_run_models_gpu_${{ env.matrix_folders }}_test_reports"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.machine_type }}_run_models_gpu_${{ env.matrix_folders }}_test_reports
           path: /transformers/reports/${{ matrix.machine_type }}_run_models_gpu_${{ matrix.folders }}_test_reports
@@ -297,7 +297,7 @@ jobs:
           echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
           echo "env.CI_SHA = ${{ env.CI_SHA }}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         # To avoid failure when multiple commits are merged into `main` in a short period of time.
         # Checking out to an old commit beyond the fetch depth will get an error `fatal: reference is not a tree: ...
         # (Only required for `workflow_run` event, where we get the latest HEAD on `main` instead of the event commit)
@@ -312,7 +312,7 @@ jobs:
           git checkout ${{ env.CI_SHA }}
           echo "log = $(git log -n 1)"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       - name: Send message to Slack
         env:
           CI_SLACK_BOT_TOKEN: ${{ secrets.CI_SLACK_BOT_TOKEN }}

--- a/.github/workflows/transformers_amd_ci_scheduled.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout transformers
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
 
@@ -204,7 +204,7 @@ jobs:
 
       - name: "Test suite reports artifacts: ${{ matrix.machine_type }}_run_pipelines_torch_gpu_test_reports"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.machine_type }}_run_pipelines_torch_gpu_test_reports
           path: /transformers/reports/${{ matrix.machine_type }}_run_pipelines_torch_gpu_test_reports
@@ -265,7 +265,7 @@ jobs:
 
       - name: "Test suite reports artifacts: ${{ matrix.machine_type }}_run_examples_gpu_test_reports"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.machine_type }}_run_examples_gpu_test_reports
           path: /transformers/reports/${{ matrix.machine_type }}_run_examples_gpu_test_reports
@@ -324,7 +324,7 @@ jobs:
 
       - name: "Test suite reports artifacts: ${{ matrix.machine_type }}_run_torch_cuda_extensions_gpu_test_reports"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.machine_type }}_run_torch_cuda_extensions_gpu_test_reports
           path: /transformers/reports/${{ matrix.machine_type }}_run_torch_cuda_extensions_gpu_test_reports
@@ -342,7 +342,7 @@ jobs:
         run_torch_cuda_extensions_gpu,
       ]
     if: ${{ always() }}
-    uses: huggingface/transformers/.github/workflows/slack-report.yml@main
+    uses: huggingface/transformers/.github/workflows/slack-report.yml@6abd9725ee7d809dc974991f8ff6c958afb63a3a  # main
     with:
       job: ${{ inputs.job }}
       # This would be `skipped` if `setup` is skipped.

--- a/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_model_jobs_arc_scale_set.yaml
@@ -149,7 +149,7 @@ jobs:
 
       - name: "Test suite reports artifacts: ${{ env.machine_type }}_run_models_gpu_${{ env.matrix_folders }}_test_reports"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ env.machine_type }}_run_models_gpu_${{ env.matrix_folders }}_test_reports
           path: /transformers/reports/${{ env.machine_type }}_run_models_gpu_${{ matrix.folders }}_test_reports
@@ -158,7 +158,7 @@ jobs:
     name: Collated Reports
     if: ${{ always() }}
     needs: run_models_gpu
-    uses: huggingface/transformers/.github/workflows/collated-reports.yml@main
+    uses: huggingface/transformers/.github/workflows/collated-reports.yml@6abd9725ee7d809dc974991f8ff6c958afb63a3a  # main
     with:
       job: run_models_gpu
       report_repo_id: ${{ inputs.report_repo_id }}


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `optimum_benchmark_instinct_ci.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `transformers_amd_ci_push.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `transformers_amd_ci_push.yaml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `transformers_amd_ci_push.yaml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `transformers_amd_ci_push.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `transformers_amd_ci_push.yaml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `transformers_amd_model_jobs_arc_scale_set.yaml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `transformers_amd_model_jobs_arc_scale_set.yaml` | `huggingface/transformers/.github/workflows/collated-reports.yml` | `main` | `main` | `6abd9725ee7d…` |
| `transformers_amd_ci_scheduled.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `transformers_amd_ci_scheduled.yaml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `transformers_amd_ci_scheduled.yaml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `transformers_amd_ci_scheduled.yaml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `transformers_amd_ci_scheduled.yaml` | `huggingface/transformers/.github/workflows/slack-report.yml` | `main` | `main` | `6abd9725ee7d…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#137