### PR TITLE
Bump AMD mi300 NUM_SLICES 2→4

### DIFF
--- a/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
+++ b/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml
@@ -36,7 +36,7 @@ env:
   RUN_SLOW: yes
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   SIGOPT_API_TOKEN: ${{ secrets.SIGOPT_API_TOKEN }}
-  NUM_SLICES: 2
+  NUM_SLICES: 4
 
 jobs:
   check_runners:


### PR DESCRIPTION
With ~518 test folders, NUM_SLICES=2 gives 259 configs per slice and hits GitHub's 256 matrix limit, so run_models_gpu never expands and no model tests run. Bumping to 4 (~130/slice) fixes it with headroom.